### PR TITLE
Add missing destructor to ManOCL.Program

### DIFF
--- a/ManOCL/Program.cs
+++ b/ManOCL/Program.cs
@@ -30,6 +30,11 @@ namespace ManOCL
 
         public IList<String> Sources { get; private set; }
 
+        ~Program()
+        {
+            OpenCLDriver.clReleaseProgram(CLProgram);
+        }
+
         /* Static methods */
 
         private static SizeT[] GetLengths(String[] sources)


### PR DESCRIPTION
Hi,

I think that `ManOCL.Program` is missing a destructor, as there are currently no callers to `OpenCLDriver.clReleaseProgram()`

This Pull Request simply adds a call to this method in the Programs **finalizer**.
