### PR TITLE
Add CL_INVALID_PROPERTY to CLError

### DIFF
--- a/ManOCL/Internal.OpenCL/CLError.cs
+++ b/ManOCL/Internal.OpenCL/CLError.cs
@@ -24,6 +24,7 @@ namespace ManOCL.Internal.OpenCL
         InvalidEventWaitList = -57,
         InvalidGlobalOffset = -56,
         InvalidGlobalWorkSize = -63,
+        InvalidProperty = -64,
         InvalidGLObject = -60,
         InvalidHostPtr = -37,
         InvalidImageFormatDescriptor = -39,


### PR DESCRIPTION
During initial testing with my Notebooks GPU I received this error-code so I thought I'd share it.

If I find the time I might add more error codes to this enumeration.

Source for error-code: http://streamcomputing.eu/blog/2013-04-28/opencl-1-2-error-codes/
